### PR TITLE
ci: Removed use of a token in the workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,6 @@ jobs:
       - name: Checkout z-wave-pc-controller
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GH_ZWAVE_ACCESS_TOKEN }}
           path: 'z-wave-pc-controller'
 
       - id: describe
@@ -59,7 +58,6 @@ jobs:
       - name: Checkout z-wave-tools-core
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GH_ZWAVE_ACCESS_TOKEN }}
           repository: 'Z-Wave-Alliance/z-wave-tools-core'
           path: 'z-wave-tools-core'
           ref: 'v25.1.0'
@@ -68,7 +66,6 @@ jobs:
       - name: Checkout z-wave-blobs
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GH_ZWAVE_ACCESS_TOKEN }}
           repository: 'Z-Wave-Alliance/z-wave-blobs'
           path: 'z-wave-blobs'
           ref: 'v0.1.1'
@@ -127,7 +124,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          token: ${{ secrets.GH_ZWAVE_ACCESS_TOKEN }}
           files: ${{ github.event.repository.name }}*.zip
 
       - name: Upload published artifacts


### PR DESCRIPTION
All PC Controller related repos are now public so the token is not needed:
- https://github.com/z-Wave-Alliance/z-wave-tools-core/
- https://github.com/z-Wave-Alliance/z-wave-blobs

<!--
SPDX-License-Identifier: BSD-3-Clause
SPDX-FileCopyrightText: 2024 Z-Wave Alliance
-->

<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/56)
  and IPR Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/43).
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on Causeway.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->

## Related issue
<!--
  Mention the related issue as described in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->
None.

## Change
<!--
  Describe your changes below.
-->
See above.


## Type of change
<!--
  What type of change does your PR introduce?
-->

- [ ] New Feature
- [ ] Bug fix
- [ ] Editorial change
- [ ] Refactoring
- [x] DevOps
- [ ] Breaking
- [ ] Other: (please describe)


## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [x] I have followed the [Contribution Guidelines][contribution-guidelines]
- [x] I agree to the [Developer Certificate of Origin][dco]
- [x] I have cleaned up my commits

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/contribution_guidelines.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
