### PR TITLE
Upgrade .NET to version 10.0.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
           repository: 'Z-Wave-Alliance/z-wave-tools-core'
           path: 'z-wave-tools-core'
           submodules: "recursive"
-          ref: 'f8560f53911ddd1f280e45a30653b02a4c5e8298'
+          ref: '8fed3174539fe5359ba123465c25b655a53fbcf9'
 
       # TODO: https://github.com/Z-Wave-Alliance/z-wave-pc-controller/issues/8
       - name: Checkout z-wave-blobs

--- a/ZWaveController/ZWaveController_netcore.csproj
+++ b/ZWaveController/ZWaveController_netcore.csproj
@@ -1,44 +1,44 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<AssemblyName>ZWaveController</AssemblyName>
-		<TargetFrameworks>net6.0</TargetFrameworks>
-		<EnableDefaultCompileItems>False</EnableDefaultCompileItems>
-	</PropertyGroup>
-	<Target Name="ClearObjFolderTarget" BeforeTargets="Restore">
-		<ItemGroup>
-			<FilesToDelete Include="obj\**\*" />
-		</ItemGroup>
-		<Delete Files="@(FilesToDelete)" />
-	</Target>
+    <PropertyGroup>
+        <AssemblyName>ZWaveController</AssemblyName>
+        <TargetFrameworks>net10.0</TargetFrameworks>
+        <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
+    </PropertyGroup>
+    <Target Name="ClearObjFolderTarget" BeforeTargets="Restore">
+        <ItemGroup>
+            <FilesToDelete Include="obj\**\*" />
+        </ItemGroup>
+        <Delete Files="@(FilesToDelete)" />
+    </Target>
   <ItemGroup>
     <Content Include="..\..\z-wave-tools-core\XmlFiles\ZWave_cmd_classes.xml">
       <Link>XmlFiles\ZWave_cmd_classes.xml</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-	<ItemGroup Condition="'$(RuntimeIdentifier)' == 'win-x64'">
-		<Content Include="..\lib\WebCamCapture\win\wcvcap64.dll" CopyToOutputDirectory="PreserveNewest" />
-	</ItemGroup>
-	<ItemGroup Condition="'$(RuntimeIdentifier)' == 'win-x86'">
-		<Content Include="..\lib\WebCamCapture\win\wcvcap32.dll" CopyToOutputDirectory="PreserveNewest" />
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="..\..\z-wave-tools-core\BasicApplication\BasicApplication_netcore.csproj" />
-		<ProjectReference Include="..\..\z-wave-tools-core\Utils\Utils_netcore.csproj" />
-		<ProjectReference Include="..\..\z-wave-tools-core\ZipApplication\ZipApplication_netcore.csproj" />
-		<ProjectReference Include="..\..\z-wave-tools-core\ZWave\ZWave_netcore.csproj" />
-		<ProjectReference Include="..\..\z-wave-tools-core\ZWaveXml\ZWaveXml_netcore.csproj" />
-	</ItemGroup>
-	<ItemGroup>
-		<Compile Include="**\*.cs" Exclude="Properties\**" />
-	</ItemGroup>
-	<ItemGroup>
-		<Compile Remove="Configuration\NetAppSettings.cs" />
-		<Compile Remove="obj\**" />
-	</ItemGroup>
-	<ItemGroup>
-	  <PackageReference Include="AutoMapper" Version="13.0.1" />
-	  <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-	</ItemGroup>
+    <ItemGroup Condition="'$(RuntimeIdentifier)' == 'win-x64'">
+        <Content Include="..\lib\WebCamCapture\win\wcvcap64.dll" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(RuntimeIdentifier)' == 'win-x86'">
+        <Content Include="..\lib\WebCamCapture\win\wcvcap32.dll" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\z-wave-tools-core\BasicApplication\BasicApplication_netcore.csproj" />
+        <ProjectReference Include="..\..\z-wave-tools-core\Utils\Utils_netcore.csproj" />
+        <ProjectReference Include="..\..\z-wave-tools-core\ZipApplication\ZipApplication_netcore.csproj" />
+        <ProjectReference Include="..\..\z-wave-tools-core\ZWave\ZWave_netcore.csproj" />
+        <ProjectReference Include="..\..\z-wave-tools-core\ZWaveXml\ZWaveXml_netcore.csproj" />
+    </ItemGroup>
+    <ItemGroup>
+        <Compile Include="**\*.cs" Exclude="Properties\**" />
+    </ItemGroup>
+    <ItemGroup>
+        <Compile Remove="Configuration\NetAppSettings.cs" />
+        <Compile Remove="obj\**" />
+    </ItemGroup>
+    <ItemGroup>
+      <PackageReference Include="AutoMapper" Version="13.0.1" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
<!--
SPDX-License-Identifier: BSD-3-Clause
SPDX-FileCopyrightText: 2024 Z-Wave Alliance
-->

<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/56)
  and IPR Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/43).
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on Causeway.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->

## Related issue
<!--
  Mention the related issue as described in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

See https://github.com/Z-Wave-Alliance/z-wave-tools-core/pull/66.
Compare https://github.com/Z-Wave-Alliance/z-wave-automated-test-system/pull/68.

## Change
<!--
  Describe your changes below.
-->

#### Upgrade .NET to version 10.0.
- This only affects the (unused) "ZWaveController_netcore" project.
  It does NOT affect the .NET Framework projects and their according
  Visual Studio solution.
- Update Tools Core to '8fed3174539fe5359ba123465c25b655a53fbcf9'.
- Whitespace corrected.

## Type of change
<!--
  What type of change does your PR introduce?
-->

- [ ] New Feature
- [ ] Bug fix
- [ ] Editorial change
- [x] Refactoring
- [ ] DevOps
- [ ] Breaking
- [ ] Other: (please describe)


## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [x] I have followed the [Contribution Guidelines][contribution-guidelines]
- [x] I agree to the [Developer Certificate of Origin][dco]
- [x] I have cleaned up my commits

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/contribution_guidelines.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
