### PR TITLE
feat: Update Z-Wave Command Classes in accordance with Z-Wave XML 2.19.1.

### DIFF
--- a/ZWaveController/Configuration/Config.cs
+++ b/ZWaveController/Configuration/Config.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using Utils;
 using ZWave.Devices;
 using ZWave.Enums;
 using ZWave.Xml.Application;
@@ -13,7 +12,8 @@ namespace ZWaveController.Configuration
 {
     public class Config : IConfig
     {
-        public static string CommandClassesXmlFilePath { get; } = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, Path.Combine("XmlFiles", Tools.ZWAVE_DEFINITION_FILE_NAME));
+        public static string CommandClassesXmlFilePath { get; } =
+            Path.Combine(AppDomain.CurrentDomain.BaseDirectory, Path.Combine("XmlFiles", Utils.Configuration.ZWAVE_DEFINITION_FILE_NAME));
 
         public TransmitOptions TxOptions { get; set; } = TransmitOptions.TransmitOptionAcknowledge | TransmitOptions.TransmitOptionAutoRoute | TransmitOptions.TransmitOptionExplore;
 


### PR DESCRIPTION
<!--
SPDX-License-Identifier: BSD-3-Clause
SPDX-FileCopyrightText: Z-Wave Alliance https://z-wavealliance.org
-->

<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/56)
  and IPR Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/43).
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on Causeway.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->

## Related issue
<!--
  Mention the related issue as described in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

Compare Tools Core PR:
- https://github.com/Z-Wave-Alliance/z-wave-tools-core/pull/74

and follow-ups:
- ZATS: https://github.com/Z-Wave-Alliance/z-wave-automated-test-system/pull/73
- Zniffer: https://github.com/Z-Wave-Alliance/z-wave-pc-zniffer/pull/34

## Change
<!--
  Describe your changes below.
-->

- feat: Update Z-Wave Command Classes in accordance with Z-Wave XML 2.19.1.

  - Breaking change: S2v2, KEX Report, "NLS Support" flag was moved to bit 3.
    Compare: https://github.com/Z-Wave-Alliance/z-wave-xml/pull/188
    S2v2 had never been certified before.

  - Updated Tools Core accordingly.

- refactor: Update Tools Core: Use file name constants from Utils.Configuration.

## Type of change
<!--
  What type of change does your PR introduce?
-->

- [x] New Feature
- [ ] Bug fix
- [ ] Editorial change
- [x] Refactoring
- [ ] DevOps
- [x] Breaking
- [ ] Other: (please describe)


## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [x] I have followed the [Contribution Guidelines][contribution-guidelines]
- [x] I agree to the [Developer Certificate of Origin][dco]
- [x] I have cleaned up my commits

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/contribution_guidelines.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
