### PR TITLE
fix: Allow handling CC Firmware Update MD versions higher than 5

### DIFF
--- a/ZWaveController/Commands/Basic/FirmwareUpdate/FirmwareUpdateOTAUpdateCommand.cs
+++ b/ZWaveController/Commands/Basic/FirmwareUpdate/FirmwareUpdateOTAUpdateCommand.cs
@@ -74,7 +74,7 @@ namespace ZWaveController.Commands
                     {
                         ControllerSession.CancelFirmwareUpdateV4(TargetDevice, elapsed);
                     }
-                    else if (FirmwareUpdateModel.FirmwareUpdateCommandClassVersion == 5)
+                    else if (FirmwareUpdateModel.FirmwareUpdateCommandClassVersion >= 5)
                     {
                         ControllerSession.CancelFirmwareUpdateV5(TargetDevice, elapsed);
                     }
@@ -158,7 +158,7 @@ namespace ZWaveController.Commands
                         ControllerSession.ApplicationModel.FirmwareUpdateModel.Activation,
                         out responseMDReportActionToken);
                 }
-                else if (ControllerSession.ApplicationModel.FirmwareUpdateModel.FirmwareUpdateCommandClassVersion == 5)
+                else if (ControllerSession.ApplicationModel.FirmwareUpdateModel.FirmwareUpdateCommandClassVersion >= 5)
                 {
                     statusByte = ControllerSession.FirmwareUpdateV5(Device, fwData,
                         ControllerSession.ApplicationModel.FirmwareUpdateModel.FirmwareChecksum,

--- a/ZWaveController/Models/BasicControllerSession.cs
+++ b/ZWaveController/Models/BasicControllerSession.cs
@@ -1144,7 +1144,7 @@ namespace ZWaveController.Models
                             ret = CommandExecutionResult.OK;
                         }
                     }
-                    else if (versionCmdClassReportData.commandClassVersion == 0x05) //V5
+                    else if (versionCmdClassReportData.commandClassVersion >= 0x05) //V5
                     {
                         var fwuGetData = new COMMAND_CLASS_FIRMWARE_UPDATE_MD_V5.FIRMWARE_MD_GET();
                         var fwuReportData = new COMMAND_CLASS_FIRMWARE_UPDATE_MD_V5.FIRMWARE_MD_REPORT();

--- a/ZWaveController/Models/ZipControllerSession.cs
+++ b/ZWaveController/Models/ZipControllerSession.cs
@@ -292,7 +292,7 @@ namespace ZWaveController.Models
                 fwuActivationSetData.firmwareTarget = (byte)ApplicationModel.FirmwareUpdateModel.SelectedFirmwareTarget.Index;
                 activateCmd = fwuActivationSetData;
             }
-            else if (ApplicationModel.FirmwareUpdateModel.FirmwareUpdateCommandClassVersion == 5)
+            else if (ApplicationModel.FirmwareUpdateModel.FirmwareUpdateCommandClassVersion >= 5)
             {
                 var fwuActivationSetData = new COMMAND_CLASS_FIRMWARE_UPDATE_MD_V5.FIRMWARE_UPDATE_ACTIVATION_SET();
                 fwuActivationSetData.manufacturerId = ApplicationModel.FirmwareUpdateModel.ManufacturerID;


### PR DESCRIPTION
z-wave-stack was recently upgraded to support CC Firmware Update MD version 8 (https://github.com/Z-Wave-Alliance/z-wave-stack/pull/887), and without this change, the PC Controller would not be able to perform a firmware update of an end device.

<!--
SPDX-License-Identifier: BSD-3-Clause
SPDX-FileCopyrightText: 2024 Z-Wave Alliance
-->

<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/56)
  and IPR Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/43).
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on Causeway.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->

## Related issue
<!--
  Mention the related issue as described in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->
None.

## Change
<!--
  Describe your changes below.
-->


## Type of change
<!--
  What type of change does your PR introduce?
-->

- [ ] New Feature
- [x] Bug fix
- [ ] Editorial change
- [ ] Refactoring
- [ ] DevOps
- [ ] Breaking
- [ ] Other: (please describe)


## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [x] I have followed the [Contribution Guidelines][contribution-guidelines]
- [x] I agree to the [Developer Certificate of Origin][dco]
- [x] I have cleaned up my commits

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/contribution_guidelines.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
